### PR TITLE
fix pipeline step rendering of env variable

### DIFF
--- a/src/main/resources/com/inneractive/jenkins/plugins/consul/operations/ConsulGetKV/config.jelly
+++ b/src/main/resources/com/inneractive/jenkins/plugins/consul/operations/ConsulGetKV/config.jelly
@@ -3,7 +3,7 @@
     <f:entry title="K/V path" field="valuePath">
         <f:textbox />
     </f:entry>
-    <f:entry title="Environment variable name" field="value">
+    <f:entry title="Environment variable name" field="environmentVariableName">
         <f:textbox />
     </f:entry>
 </j:jelly>

--- a/src/main/resources/com/inneractive/jenkins/plugins/consul/operations/ConsulServiceDiscoveryOperation/config.jelly
+++ b/src/main/resources/com/inneractive/jenkins/plugins/consul/operations/ConsulServiceDiscoveryOperation/config.jelly
@@ -17,7 +17,7 @@
     <f:entry title="Service tag" field="serviceTag">
         <f:textbox/>
     </f:entry>
-    <f:entry title="Environment variable name" field="value">
+    <f:entry title="Environment variable name" field="environmentVariableName">
         <f:textbox/>
     </f:entry>
 


### PR DESCRIPTION
This fixes a bug in the current plugin where the `environmentVariableName` field was not populating in the Pipeline step that was generated. 

For example:
```
Consul consulSettingsProfileName: 'myprofile', installationName: 'consul', operationList: [[$class: 'ConsulGetKV', valuePath: 'dc1/mykey']]
```

Now this should generate correctly with:
```
Consul consulSettingsProfileName: 'myprofile', installationName: 'consul', operationList: [[$class: 'ConsulGetKV', environmentVariableName: 'myenvvar', valuePath: 'dc1/mykey']]
```

However, I have also found that the environment variable never gets set. @liozN has that ever worked for you? I can't seem to `echo ${env.myenvvar}` to get it out nor do I see it when printing `env`. I can follow up with a bug report in the morning. 

EDIT: Looks like the bug is only with pipeline, in freestyle jobs I can `echo ${myenvvar}` like your screenshots and that seems to work.